### PR TITLE
Keyfifth flip examples

### DIFF
--- a/docs/static/examples/json/keyfifths-flip-2.json
+++ b/docs/static/examples/json/keyfifths-flip-2.json
@@ -1,0 +1,104 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {
+                "barline": {
+                    "type": "double"
+                },
+                "key": {
+                    "fifths": 4
+                },
+                "time": {
+                    "count": 4,
+                    "unit": 4
+                }
+            },
+            {
+                "key": {
+                    "fifths": 6
+                }
+            }
+        ]
+    },
+    "parts": [
+        {
+            "id": "concert",
+            "name": "Concert",
+            "measures": [
+                {
+                    "sequences": [],
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2,
+                                "glyph": "gClef"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        },
+        {
+            "id": "eflat-flipat-7",
+            "name": "in Eb +7",
+            "transposition": {
+                "interval": {
+                    "halfSteps": 9,
+                    "staffDistance": 5
+                },
+                "keyFifthsFlipAt": 7
+            },
+            "measures": [
+                {
+                    "sequences": [],
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2,
+                                "glyph": "gClef"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        },
+        {
+            "id": "eflat-flipat-none",
+            "name": "in Eb (no flip)",
+            "transposition": {
+                "interval": {
+                    "halfSteps": 9,
+                    "staffDistance": 5
+                }
+            },
+            "measures": [
+                {
+                    "sequences": [],
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2,
+                                "glyph": "gClef"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        }
+    ]
+}

--- a/docs/static/examples/json/keyfiths-flip.json
+++ b/docs/static/examples/json/keyfiths-flip.json
@@ -1,0 +1,143 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {
+                "key": {
+                    "fifths": 3
+                },
+                "time": {
+                    "count": 4,
+                    "unit": 4
+                }
+            },
+            {
+                "key": {
+                    "fifths": 5
+                }
+            },
+            {
+                "key": {
+                    "fifths": 6
+                }
+            }
+        ]
+    },
+    "parts": [
+        {
+            "id": "concert",
+            "name": "Concert",
+            "measures": [
+                {
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2
+                            }
+                        }
+                    ],
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        },
+        {
+            "id": "bflat-flipat-5",
+            "name": "in B♭ +5",
+            "transposition": {
+                "interval": {
+                    "halfSteps": 2,
+                    "staffDistance": 1
+                },
+                "keyFifthsFlipAt": 5
+            },
+            "measures": [
+                {
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2
+                            }
+                        }
+                    ],
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        },
+        {
+            "id": "bflat-flipat-7",
+            "name": "in B♭ +7",
+            "transposition": {
+                "interval": {
+                    "halfSteps": 2,
+                    "staffDistance": 1
+                },
+                "keyFifthsFlipAt": 7
+            },
+            "measures": [
+                {
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2
+                            }
+                        }
+                    ],
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        },
+        {
+            "id": "bflat-flipat-8",
+            "name": "in B♭ +8",
+            "transposition": {
+                "interval": {
+                    "halfSteps": 2,
+                    "staffDistance": 1
+                },
+                "keyFifthsFlipAt": 8
+            },
+            "measures": [
+                {
+                    "clefs": [
+                        {
+                            "clef": {
+                                "sign": "G",
+                                "staffPosition": -2
+                            }
+                        }
+                    ],
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                },
+                {
+                    "sequences": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR proposes two new examples to clarify edge cases around `keyFifthsFlipAt` in `part-transposition`. I would have preferred to combine them in a single example, but my tools (MuseScore and Finale) each can only do part of the example.

- `keyfifths-flip.json` illustrates flipping around the edge case values `5`, `7`, and `8`. The result is this:

<img width="434" height="242" alt="Screenshot 2026-02-07 at 7 48 02 AM" src="https://github.com/user-attachments/assets/c8147a83-595f-43c1-bbcc-655449a3f2be" />

- `keyfifths-flip-2.json` illustrates what happens if `keyFifthsFlipAt` is omitted:

<img width="417" height="199" alt="Screenshot 2026-02-07 at 8 05 42 AM" src="https://github.com/user-attachments/assets/94ae74e8-4962-47e9-bcac-c5a6e98be179" />

One reason I am submitting these examples is that I want to be certain that I have interpreted the text of the specification correctly.
