### PR TITLE
Document measure repeat orientation default

### DIFF
--- a/doctools/data.json
+++ b/doctools/data.json
@@ -6659,7 +6659,11 @@
         "child_key": "orient",
         "child": 213,
         "is_required": false,
-        "description": "Where to display the count. If not provided, consuming applications should use their own algorithms."
+        "description": [
+            "Where to display the count.",
+            "",
+            "If not provided, the default value is \"auto\"."
+        ]
     }
 },
 {


### PR DESCRIPTION
Fixes #535.

States explicitly that `measure-repeat-counter.orient` defaults to `auto`, matching the equivalent `dynamic-group.orient` documentation.

Validation: parsed `doctools/data.json` and verified the relationship description structure matches the existing dynamic-group form.
